### PR TITLE
a couple of bug fixes

### DIFF
--- a/consolidatethread.py
+++ b/consolidatethread.py
@@ -114,13 +114,25 @@ class ConsolidateTask(QgsTask):
         if self.isCanceled():
             raise TaskCanceled('Consolidation canceled')
 
+        usedFilenames = []
         for i, layer in enumerate(layers.values()):
             if not layer.isValid():
                 raise TypeError("Layer %s is invalid" % layer.name())
             lType = layer.type()
 #            QgsMessageLog.logMessage("!: '%s'" % lType, 'QConsolidate3', level=Qgis.Info)
             lProviderType = layer.providerType()
-            lName = layer.name()
+            # ensure filename is valid
+            lName = re.sub(r'[\/:*?"<>|]', '_', layer.name())
+            # ensure this layer name is unique
+            newLName = lName
+            count = 2
+            while newLName in usedFilenames:
+                newLName = lName + '_' + str(count)
+                count += 1
+            lName = newLName
+            # note this filename is used
+            usedFilenames.append(lName)
+            
             lID = layer.id()
             lUri = layer.dataProvider().dataSourceUri()
             if lType == QgsMapLayer.VectorLayer:

--- a/qconsolidatedialog.py
+++ b/qconsolidatedialog.py
@@ -196,7 +196,7 @@ class QConsolidateDialog(QDialog):
         # copy project file
         projectFile = QgsProject.instance().fileName()
         try:
-            if projectFile:
+            if os.path.isfile(projectFile):
                 f = QFile(projectFile)
                 newProjectFile = os.path.join(outputDir,
                                               '%s.qgs' % project_name)


### PR DESCRIPTION
fixes include: 
1) if the current project has an associated filename, but has been removed from disk then the plugin will fail because it attempts to copy the file first. Solution is to check if the file exists on disk before attempting to copy it

2) if multiple layers have the same name then the each layer in the list will overwrite the previously written file. The solution is to make sure that each filename is unique (and valid) by appending _2, _3 etc. to previously used filenames 